### PR TITLE
Add basic PEB energy assessment package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/peb/__init__.py
+++ b/peb/__init__.py
@@ -1,0 +1,25 @@
+"""PEB package implementing a simplified building energy assessment."""
+
+from .models import Building, Wall, Window, HeatingSystem
+from .config import REGIONAL_CONFIG
+from .calculations import (
+    energy_need,
+    primary_energy,
+    energy_score,
+)
+try:
+    from .export import export_certificate
+except Exception:  # pragma: no cover - optional dependency
+    export_certificate = None
+
+__all__ = [
+    "Building",
+    "Wall",
+    "Window",
+    "HeatingSystem",
+    "REGIONAL_CONFIG",
+    "energy_need",
+    "primary_energy",
+    "energy_score",
+    "export_certificate",
+]

--- a/peb/calculations.py
+++ b/peb/calculations.py
@@ -1,0 +1,30 @@
+"""Calculation routines for PEB."""
+
+from .models import Building
+from .config import REGIONAL_CONFIG
+
+
+DEGREE_DAY_CONSTANT = 0.024  # (kWh/degree day)
+
+
+def energy_need(building: Building, region: str) -> float:
+    """Return annual heating energy need in kWh."""
+    cfg = REGIONAL_CONFIG[region]
+    dd = cfg["degree_days"]
+    loss = sum(w.area * w.u_value for w in building.walls)
+    loss += sum(w.area * w.u_value for w in building.windows)
+    return loss * dd * DEGREE_DAY_CONSTANT
+
+
+def primary_energy(building: Building, region: str) -> float:
+    """Convert energy need to primary energy (kWh)."""
+    need = energy_need(building, region)
+    efficiency = building.heating.efficiency
+    cfg = REGIONAL_CONFIG[region]
+    return need / efficiency * cfg["conversion_factor"]
+
+
+def energy_score(building: Building, region: str) -> float:
+    """Compute energy score per square meter."""
+    pe = primary_energy(building, region)
+    return pe / building.area

--- a/peb/config.py
+++ b/peb/config.py
@@ -1,0 +1,19 @@
+"""Regional configuration for PEB calculations."""
+
+REGIONAL_CONFIG = {
+    "wallonia": {
+        "version": "2023",
+        "degree_days": 2200,
+        "conversion_factor": 1.1,
+    },
+    "brussels": {
+        "version": "2023",
+        "degree_days": 2000,
+        "conversion_factor": 1.2,
+    },
+    "flanders": {
+        "version": "2023",
+        "degree_days": 2100,
+        "conversion_factor": 1.0,
+    },
+}

--- a/peb/examples/usage.py
+++ b/peb/examples/usage.py
@@ -1,0 +1,32 @@
+"""Example script showing how to use the peb package."""
+
+from peb import (
+    Building,
+    Wall,
+    Window,
+    HeatingSystem,
+    energy_need,
+    primary_energy,
+    energy_score,
+    export_certificate,
+)
+
+
+def main() -> None:
+    building = Building(
+        walls=[Wall(area=100, u_value=0.3)],
+        windows=[Window(area=20, u_value=1.2)],
+        heating=HeatingSystem(efficiency=0.9),
+    )
+
+    region = "wallonia"
+    print("Energy need:", energy_need(building, region))
+    print("Primary energy:", primary_energy(building, region))
+    print("Score:", energy_score(building, region))
+
+    export_certificate(building, region, "certificate.pdf", "certificate.xml")
+    print("Certificate exported.")
+
+
+if __name__ == "__main__":
+    main()

--- a/peb/export.py
+++ b/peb/export.py
@@ -1,0 +1,41 @@
+"""Export routines for PEB certificates."""
+
+from __future__ import annotations
+
+from xml.etree.ElementTree import Element, tostring
+
+from fpdf import FPDF
+
+from .models import Building
+from .calculations import energy_score
+from .config import REGIONAL_CONFIG
+
+
+class CertificatePDF(FPDF):
+    """Very small PDF for PEB certificate."""
+
+    def header(self):
+        self.set_font("Arial", "B", 16)
+        self.cell(0, 10, "PEB Certificate", ln=True, align="C")
+
+
+def export_certificate(building: Building, region: str, pdf_path: str, xml_path: str) -> None:
+    """Export building certificate to PDF and XML."""
+    score = energy_score(building, region)
+
+    pdf = CertificatePDF()
+    pdf.add_page()
+    pdf.set_font("Arial", size=12)
+    pdf.cell(0, 10, f"Region: {region.title()} ({REGIONAL_CONFIG[region]['version']})", ln=True)
+    pdf.cell(0, 10, f"Energy score: {score:.2f} kWh/m²", ln=True)
+    pdf.output(pdf_path)
+
+    root = Element("certificate")
+    root.set("region", region)
+    root.set("version", REGIONAL_CONFIG[region]["version"])
+    score_elem = Element("energy_score")
+    score_elem.text = f"{score:.2f}"
+    root.append(score_elem)
+
+    with open(xml_path, "wb") as f:
+        f.write(tostring(root))

--- a/peb/models.py
+++ b/peb/models.py
@@ -1,0 +1,43 @@
+"""Data models for building energy performance."""
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class Wall:
+    """External wall of a building."""
+
+    area: float  # m^2
+    u_value: float  # W/(m^2 K)
+
+
+@dataclass
+class Window:
+    """Window of a building."""
+
+    area: float  # m^2
+    u_value: float  # W/(m^2 K)
+
+
+@dataclass
+class HeatingSystem:
+    """Simple heating system representation."""
+
+    efficiency: float  # between 0 and 1
+
+
+@dataclass
+class Building:
+    """Simplified building model."""
+
+    walls: List[Wall] = field(default_factory=list)
+    windows: List[Window] = field(default_factory=list)
+    heating: HeatingSystem = field(
+        default_factory=lambda: HeatingSystem(efficiency=0.9)
+    )
+
+    @property
+    def area(self) -> float:
+        """Total area of opaque and glazed surfaces."""
+        return sum(w.area for w in self.walls) + sum(w.area for w in self.windows)

--- a/peb/tests/test_calculations.py
+++ b/peb/tests/test_calculations.py
@@ -1,0 +1,37 @@
+import unittest
+
+from peb import (
+    Building,
+    Wall,
+    Window,
+    HeatingSystem,
+    energy_need,
+    primary_energy,
+    energy_score,
+)
+
+
+class CalculationTests(unittest.TestCase):
+    def setUp(self):
+        self.building = Building(
+            walls=[Wall(area=100, u_value=0.3)],
+            windows=[Window(area=20, u_value=1.2)],
+            heating=HeatingSystem(efficiency=0.9),
+        )
+        self.region = "wallonia"
+
+    def test_energy_need(self):
+        need = energy_need(self.building, self.region)
+        self.assertGreater(need, 0)
+
+    def test_primary_energy(self):
+        pe = primary_energy(self.building, self.region)
+        self.assertGreater(pe, 0)
+
+    def test_energy_score(self):
+        score = energy_score(self.building, self.region)
+        self.assertGreater(score, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- introduce `peb` package implementing a basic PEB energy assessment
- include data models for building elements and systems
- provide regional configuration and calculation utilities
- support simple PDF/XML certificate export
- add example usage script and unit tests

## Testing
- `python -m unittest discover -v peb/tests`

------
https://chatgpt.com/codex/tasks/task_e_68483661485883329917e2c8f4791890