### PR TITLE
Add infiltration loss to heating calculations

### DIFF
--- a/peb/calculations.py
+++ b/peb/calculations.py
@@ -11,9 +11,16 @@ def energy_need(building: Building, region: str) -> float:
     """Return annual heating energy need in kWh."""
     cfg = REGIONAL_CONFIG[region]
     dd = cfg["degree_days"]
-    loss = sum(w.area * w.u_value for w in building.walls)
-    loss += sum(w.area * w.u_value for w in building.windows)
-    return loss * dd * DEGREE_DAY_CONSTANT
+    wall_window_loss = sum(w.area * w.u_value for w in building.walls)
+    wall_window_loss += sum(w.area * w.u_value for w in building.windows)
+
+    loss = wall_window_loss * dd * DEGREE_DAY_CONSTANT
+
+    infiltration_loss = (
+        building.infiltration_rate * building.floor_area * dd * DEGREE_DAY_CONSTANT
+    )
+
+    return loss + infiltration_loss
 
 
 def primary_energy(building: Building, region: str) -> float:

--- a/peb/examples/usage.py
+++ b/peb/examples/usage.py
@@ -14,6 +14,7 @@ from peb import (
 
 def main() -> None:
     building = Building(
+        floor_area=120,
         walls=[Wall(area=100, u_value=0.3)],
         windows=[Window(area=20, u_value=1.2)],
         heating=HeatingSystem(efficiency=0.9),

--- a/peb/models.py
+++ b/peb/models.py
@@ -31,6 +31,8 @@ class HeatingSystem:
 class Building:
     """Simplified building model."""
 
+    floor_area: float  # m^2 of conditioned floor area
+    infiltration_rate: float = 0.6  # air changes per hour
     walls: List[Wall] = field(default_factory=list)
     windows: List[Window] = field(default_factory=list)
     heating: HeatingSystem = field(

--- a/peb/tests/test_calculations.py
+++ b/peb/tests/test_calculations.py
@@ -14,6 +14,7 @@ from peb import (
 class CalculationTests(unittest.TestCase):
     def setUp(self):
         self.building = Building(
+            floor_area=120,
             walls=[Wall(area=100, u_value=0.3)],
             windows=[Window(area=20, u_value=1.2)],
             heating=HeatingSystem(efficiency=0.9),
@@ -31,6 +32,27 @@ class CalculationTests(unittest.TestCase):
     def test_energy_score(self):
         score = energy_score(self.building, self.region)
         self.assertGreater(score, 0)
+
+    def test_infiltration_effect(self):
+        b_no_inf = Building(
+            floor_area=120,
+            walls=[Wall(area=100, u_value=0.3)],
+            windows=[Window(area=20, u_value=1.2)],
+            heating=HeatingSystem(efficiency=0.9),
+            infiltration_rate=0.0,
+        )
+        base = energy_need(b_no_inf, self.region)
+
+        b_high_inf = Building(
+            floor_area=120,
+            walls=[Wall(area=100, u_value=0.3)],
+            windows=[Window(area=20, u_value=1.2)],
+            heating=HeatingSystem(efficiency=0.9),
+            infiltration_rate=1.2,
+        )
+        high = energy_need(b_high_inf, self.region)
+
+        self.assertGreater(high, base)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend `Building` model with `floor_area` and `infiltration_rate`
- include infiltration heat loss in `energy_need`
- test the effect of infiltration and update fixtures
- adjust example usage to show new parameter

## Testing
- `PYTHONPATH=. pytest peb/tests/test_calculations.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684838694580833284460d780c58dd21