### PR TITLE
Add design pattern examples

### DIFF
--- a/Design Patterns/Factory.py
+++ b/Design Patterns/Factory.py
@@ -1,0 +1,38 @@
+from abc import ABC, abstractmethod
+
+
+class Shape(ABC):
+    @abstractmethod
+    def draw(self):
+        pass
+
+
+class Circle(Shape):
+    def draw(self):
+        print("Circle")
+
+
+class Square(Shape):
+    def draw(self):
+        print("Square")
+
+
+class ShapeFactory:
+    def get_shape(self, shape_type: str) -> Shape:
+        if shape_type == "circle":
+            return Circle()
+        if shape_type == "square":
+            return Square()
+        raise ValueError("Unknown shape")
+
+
+def client_code():
+    factory = ShapeFactory()
+    shape1 = factory.get_shape("circle")
+    shape1.draw()
+    shape2 = factory.get_shape("square")
+    shape2.draw()
+
+
+if __name__ == "__main__":
+    client_code()

--- a/Design Patterns/Observer.py
+++ b/Design Patterns/Observer.py
@@ -1,0 +1,27 @@
+class Subject:
+    def __init__(self):
+        self._observers = []
+
+    def attach(self, observer):
+        self._observers.append(observer)
+
+    def notify(self, message):
+        for obs in self._observers:
+            obs.update(message)
+
+
+class Observer:
+    def __init__(self, name):
+        self.name = name
+
+    def update(self, message):
+        print(f"{self.name} received {message}")
+
+
+if __name__ == "__main__":
+    subject = Subject()
+    observer_a = Observer("A")
+    observer_b = Observer("B")
+    subject.attach(observer_a)
+    subject.attach(observer_b)
+    subject.notify("event")

--- a/Design Patterns/Singleton.py
+++ b/Design Patterns/Singleton.py
@@ -1,0 +1,18 @@
+class SingletonMeta(type):
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super().__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+
+class Singleton(metaclass=SingletonMeta):
+    """Example singleton object"""
+    pass
+
+
+if __name__ == "__main__":
+    first = Singleton()
+    second = Singleton()
+    print(first is second)

--- a/Design Patterns/Strategy.py
+++ b/Design Patterns/Strategy.py
@@ -1,0 +1,24 @@
+from typing import Callable
+
+
+class Context:
+    def __init__(self, strategy: Callable[[int, int], int]):
+        self.strategy = strategy
+
+    def execute(self, a: int, b: int) -> int:
+        return self.strategy(a, b)
+
+
+def add(x: int, y: int) -> int:
+    return x + y
+
+
+def multiply(x: int, y: int) -> int:
+    return x * y
+
+
+if __name__ == "__main__":
+    context = Context(add)
+    print(context.execute(2, 3))
+    context.strategy = multiply
+    print(context.execute(2, 3))

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Ce depot rassemble plusieurs projets et scripts Python varies. Vous y trouverez 
 - **Chatbot** – Quelques essais autour de la generation de reponses avec la bibliotheque `chatterbot` et des exemples de synthese ou reconnaissance vocale.
 - **Chimie** – Fonctions et petits programmes sur des notions chimiques (calcul de pH, configuration electronique…).
 - **Dashboard** – Exemple minimal d'utilisation de la bibliotheque `cuxfilter` pour creer un tableau de bord interactif.
-- **Design Patterns** – Illustrations de certains patrons de conception, par exemple le patron Composite.
+- **Design Patterns** – Illustrations de plusieurs patrons de conception : Composite, Singleton, Factory, Observer et Strategy.
 - **ETL** – Script de demonstration d'un processus Extract/Transform/Load (attention : dependances manquantes et noms de modules parfois incorrects).
 - **Ethical Hacking** – Exemple tres basique d'echanges reseau via sockets (client et serveur).
 - **PizzaMama** – Exemple d'application console consommant une API de pizzeria ; voir egalement le projet Django dans `PizzaMamaDjango`.


### PR DESCRIPTION
## Summary
- add Factory, Observer, Singleton and Strategy design pattern examples
- document new design patterns in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'kivy')*

------
https://chatgpt.com/codex/tasks/task_e_684c302b21bc8332bc718502793e106f