### PR TITLE
Add Decorator and Adapter design patterns

### DIFF
--- a/Design Patterns/Adapter.py
+++ b/Design Patterns/Adapter.py
@@ -1,0 +1,25 @@
+class FrenchSpeaker:
+    def bonjour(self) -> str:
+        return "Bonjour"
+
+
+class EnglishSpeaker:
+    def hello(self) -> str:
+        return "Hello"
+
+
+class FrenchToEnglishAdapter:
+    def __init__(self, speaker: FrenchSpeaker):
+        self.speaker = speaker
+
+    def hello(self) -> str:
+        return self.speaker.bonjour()
+
+
+if __name__ == "__main__":
+    french = FrenchSpeaker()
+    adapter = FrenchToEnglishAdapter(french)
+    english = EnglishSpeaker()
+
+    print(english.hello())
+    print(adapter.hello())

--- a/Design Patterns/Decorator.py
+++ b/Design Patterns/Decorator.py
@@ -1,0 +1,25 @@
+class Text:
+    def render(self) -> str:
+        return "Text"
+
+
+class BoldDecorator:
+    def __init__(self, wrapped):
+        self.wrapped = wrapped
+
+    def render(self) -> str:
+        return f"<b>{self.wrapped.render()}</b>"
+
+
+class ItalicDecorator:
+    def __init__(self, wrapped):
+        self.wrapped = wrapped
+
+    def render(self) -> str:
+        return f"<i>{self.wrapped.render()}</i>"
+
+
+if __name__ == "__main__":
+    simple = Text()
+    decorated = BoldDecorator(ItalicDecorator(simple))
+    print(decorated.render())

--- a/Design Patterns/README.md
+++ b/Design Patterns/README.md
@@ -11,6 +11,8 @@ Ce dossier presente plusieurs patrons de conception classiques en Python. Les fi
 | Observer   | Pour notifier plusieurs objets (observers) qu'un evenement s'est produit dans un autre objet (subject) sans couplage fort. |
 | Strategy   | Quand plusieurs algorithmes sont interchangeables a l'execution. Le contexte peut changer la strategie au vol. |
 | Composite  | Pour manipuler de maniere uniforme des objets simples et des compositions d'objets. |
+| Decorator  | Pour ajouter dynamiquement des fonctionnalites a un objet sans modifier son code d'origine. |
+| Adapter    | Pour adapter l'interface d'un objet a celle attendue par le client. |
 
 ## Comment les mettre en oeuvre ?
 
@@ -19,3 +21,5 @@ Ce dossier presente plusieurs patrons de conception classiques en Python. Les fi
 - **Observer** : definir un `Subject` qui conserve une liste d'observateurs et les notifie via une methode commune (`update`). Voir `Observer.py`.
 - **Strategy** : definir plusieurs fonctions ou classes encapsulant des algorithmes; le `Context` possede une reference a la strategie et la delegue. Voir `Strategy.py`.
 - **Composite** : chaque objet de la composition possede la meme interface que les objets simples pour pouvoir les traiter de la meme maniere. Voir `Composite.py`.
+- **Decorator** : envelopper un objet pour lui ajouter des comportements au moment de l'execution sans toucher a son code. Voir `Decorator.py`.
+- **Adapter** : encapsuler un objet pour presenter l'interface qu'attend le client. Voir `Adapter.py`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Ce depot rassemble plusieurs projets et scripts Python varies. Vous y trouverez 
 - **Chatbot** – Quelques essais autour de la generation de reponses avec la bibliotheque `chatterbot` et des exemples de synthese ou reconnaissance vocale.
 - **Chimie** – Fonctions et petits programmes sur des notions chimiques (calcul de pH, configuration electronique…).
 - **Dashboard** – Exemple minimal d'utilisation de la bibliotheque `cuxfilter` pour creer un tableau de bord interactif.
-- **Design Patterns** – Illustrations de plusieurs patrons de conception : Composite, Singleton, Factory, Observer et Strategy. Voir [Design Patterns/README.md](Design Patterns/README.md) pour savoir quand et comment les utiliser.
+- **Design Patterns** – Illustrations de plusieurs patrons de conception : Composite, Singleton, Factory, Observer, Strategy ainsi que Decorator et Adapter. Voir [Design Patterns/README.md](Design Patterns/README.md) pour savoir quand et comment les utiliser.
 - **ETL** – Script de demonstration d'un processus Extract/Transform/Load (attention : dependances manquantes et noms de modules parfois incorrects).
 - **Ethical Hacking** – Exemple tres basique d'echanges reseau via sockets (client et serveur).
 - **PizzaMama** – Exemple d'application console consommant une API de pizzeria ; voir egalement le projet Django dans `PizzaMamaDjango`.


### PR DESCRIPTION
## Summary
- implement new design patterns: Decorator and Adapter
- document new patterns in `Design Patterns/README.md`
- mention Decorator and Adapter in repository root README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for optional dependencies)*
- `python 'Design Patterns/Decorator.py'`
- `python 'Design Patterns/Adapter.py'`


------
https://chatgpt.com/codex/tasks/task_e_684c35300ff48332919cba338b6e3fb9